### PR TITLE
Use a stable Alpine version instead of edge to avoid untrusted signtures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:edge
-MAINTAINER Arnaud de Mouhy <arnaud@admds.net>
+FROM alpine:3.16
+LABEL maintainer="Arnaud de Mouhy <arnaud@admds.net>"
 
 ARG VCS_REF
 ARG BUILD_DATE


### PR DESCRIPTION
## Problem

Recently I've been getting the following error messages when trying to use `dehy/adminer`:

```sh
fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
ERROR: https://dl-cdn.alpinelinux.org/alpine/edge/main: UNTRUSTED signature
fetch https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
ERROR: https://dl-cdn.alpinelinux.org/alpine/edge/community: UNTRUSTED signature
v20210212-7302-g4df6acb4f5 [https://dl-cdn.alpinelinux.org/alpine/edge/main]
v20210212-7296-g7c150a48ef [https://dl-cdn.alpinelinux.org/alpine/edge/community]
2 errors; 14869 distinct packages available
```
Let's use a stable Alpine version instead of edge to avoid untrusted signtures. `alpine:3.16` is the last version matching with the current `rootfs/build.sh` packages:

- https://git.alpinelinux.org/aports/tree/community/php8?h=3.16-stable - OK
- https://git.alpinelinux.org/aports/tree/community/php8?h=3.17-stable - Path not found